### PR TITLE
Disable Ingress Temporarily

### DIFF
--- a/home-panel/Dockerfile
+++ b/home-panel/Dockerfile
@@ -17,7 +17,7 @@ RUN \
         nodejs-current=12.4.0-r0 \
     \
     && curl -J -L -o /tmp/panel.zip \
-        "https://github.com/timmo001/home-panel/releases/download/v1.0.0/home-panel-built.zip" \
+        "https://github.com/timmo001/home-panel/releases/download/v1.0.0/home-panel-built-v0.10.0.zip" \
     && unzip -d /tmp /tmp/panel.zip \
     && mv /tmp/build /opt/panel \
     \

--- a/home-panel/config.json
+++ b/home-panel/config.json
@@ -17,16 +17,13 @@
   "hassio_role": "default",
   "hassio_api": true,
   "homeassistant_api": true,
-  "ingress": true,
-  "ingress_port": 1337,
-  "panel_icon": "mdi:home",
-  "homeassistant": "0.92.0b2",
+  "ingress": false,
   "ports": {
-    "80/tcp": null,
+    "80/tcp": 8234,
     "3234/tcp": 3234
   },
   "ports_description": {
-    "80/tcp": "Web UI (Not required for Hass.io Ingress)",
+    "80/tcp": "Web UI",
     "3234/tcp": "API"
   },
   "map": [

--- a/home-panel/rootfs/etc/cont-init.d/nginx.sh
+++ b/home-panel/rootfs/etc/cont-init.d/nginx.sh
@@ -5,8 +5,6 @@
 # ==============================================================================
 declare port
 declare certfile
-declare ingress_interface
-declare ingress_port
 declare keyfile
 
 port=$(bashio::addon.port 80)
@@ -25,8 +23,3 @@ if bashio::var.has_value "${port}"; then
         mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf
     fi
 fi
-
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
-sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf

--- a/home-panel/rootfs/etc/nginx/servers/ingress.conf
+++ b/home-panel/rootfs/etc/nginx/servers/ingress.conf
@@ -1,8 +1,0 @@
-server {
-    listen %%interface%%:%%port%% default_server;
-
-    include /etc/nginx/includes/server_params.conf;
-
-    allow   172.30.32.2;
-    deny    all;
-}


### PR DESCRIPTION
# Proposed Changes

Too many users have been having issues with ingress. Mainly due to the fact that the API still has to be exposed which will not work under another host (for example nabu casa). This PR removes ingress support because of this fact.

This is temporary though as hopefully :crossed_fingers: The next release of Home Panel will work with one port, meaning that ingress *should* be possible (#25)

## Related Issues

Fixes #21 
Fixes #24 
Fixes #26 

