### PR TITLE
🚑Change format of sed command, add logging

### DIFF
--- a/home-panel/rootfs/etc/cont-init.d/secrets.sh
+++ b/home-panel/rootfs/etc/cont-init.d/secrets.sh
@@ -14,7 +14,9 @@ fi
 key=$(cat /data/secret.txt)
 
 # Set secret to persistent secret file
-sed -i "s/API_AUTH_SECRET/${key}/g" /opt/panel/config/default.json
+bashio::log.info "Update secret in config"
+sed -i "s#API_AUTH_SECRET#${key}#g" /opt/panel/config/default.json
 
 # Set database to /data
+bashio::log.info "Update database path in config"
 sed -i "s#../db#/data#g" /opt/panel/config/default.json


### PR DESCRIPTION
# Proposed Changes

The `openssl rand -base64 32` command used to generate the secret can contain the `/` character.  Changing the sed command to use a different delimiter to avoid the issue, also added logging to see which fails in the future.

## Related Issues

Fixes #32 
