### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/home-panel/config.json
+++ b/home-panel/config.json
@@ -4,7 +4,6 @@
   "slug": "home-panel",
   "description": "A web frontend for controlling the home",
   "url": "https://github.com/hassio-addons/addon-home-panel",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:80]",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "init": false,
   "hassio_api": true,


### PR DESCRIPTION
# Proposed Changes

Removes the `webui` configuration option. It isn't used, since this add-on uses Ingress.
