### PR TITLE
Upgrade add-on base image to 9.1.2

### DIFF
--- a/home-panel/Dockerfile
+++ b/home-panel/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/base:8.0.3
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.2
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -12,13 +12,13 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache --virtual .build-dependencies \
-        tar=1.32-r1 \
+        tar=1.33-r1 \
     \
     && apk add --no-cache \
-        nginx=1.18.0-r0 \
-        nodejs-current=14.5.0-r0 \
-        openssl=1.1.1g-r0 \
-        yarn=1.22.4-r0 \
+        nginx=1.18.0-r13 \
+        nodejs-current=15.5.1-r0 \
+        openssl=1.1.1i-r0 \
+        yarn=1.22.10-r0 \
     \
     && mkdir -p /opt/panel \
     && curl -L -s "https://github.com/timmo001/home-panel/releases/download/v2.10.2/home-panel.tar.gz" \
@@ -27,7 +27,7 @@ RUN \
     && cd /opt/panel \
     && yarn install \
     \
-    && apk del --purge .build-dependencies \
+    && apk del --no-cache --purge .build-dependencies \
     && rm -fr /tmp/*
 
 # Build arguments

--- a/home-panel/build.json
+++ b/home-panel/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "hassioaddons/base-aarch64:8.0.3",
-    "amd64": "hassioaddons/base-amd64:8.0.3",
-    "armhf": "hassioaddons/base-armhf:8.0.3",
-    "armv7": "hassioaddons/base-armv7:8.0.3",
-    "i386": "hassioaddons/base-i386:8.0.3"
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.2",
+    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.2",
+    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.2",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.2",
+    "i386": "ghcr.io/hassio-addons/base/i386:9.1.2"
   }
 }

--- a/home-panel/config.json
+++ b/home-panel/config.json
@@ -6,7 +6,6 @@
   "url": "https://github.com/hassio-addons/addon-home-panel",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "init": false,
-  "hassio_api": true,
   "homeassistant": "0.91.4",
   "homeassistant_api": true,
   "ingress": true,


### PR DESCRIPTION
# Proposed Changes

Upgrade add-on base image to 9.1.2, brings in the new Alpine 3.13 (and its updated packages).
